### PR TITLE
Bump app memory requirement to 64MiB

### DIFF
--- a/kubernetes/app.yaml
+++ b/kubernetes/app.yaml
@@ -26,7 +26,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 32Mi
+            memory: 64Mi
         env:
         - name: CONSUL_HTTP_ADDR
           value: 169.254.1.1:8500


### PR DESCRIPTION
Bump app memory requirement to 64MiB to avoid being killed by OOM killer.